### PR TITLE
Add PUBSUB_DEFAULT_PROJECT_ID env for default project selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 #
 # PUBSUB_EMULATOR_URL=<host>:<port>
 # PUBSUB_PRE_CONFIGURED_MSG_ATTR='{"eventType":"default", "source":"emulator"}'
+# PUBSUB_DEFAULT_PROJECT_ID=my-gcp-project
 #
 # STORAGE_EMULATOR_URL=<host>:<port>
 # FIRESTORE_EMULATOR_URL=<host>:<port>

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Currently supported runtime fields:
   "pubsub": {
     "pubsubPreConfiguredMsgAttr": {
       "key": "value"
-    }
+    },
+    "defaultProjectId": "my-gcp-project"
   }
 }
 ```
@@ -115,6 +116,16 @@ To set `pubsubPreConfiguredMsgAttr`, provide a JSON object in the `PUBSUB_PRE_CO
 docker run \
    --rm \
    --env PUBSUB_PRE_CONFIGURED_MSG_ATTR='{"source":"local","env":"dev"}' \
+   --publish 9090:80 \
+   ghcr.io/drehelis/gcp-emulator-ui:main
+```
+
+To set a default project selected on startup, use the `PUBSUB_DEFAULT_PROJECT_ID` environment variable:
+
+```bash
+docker run \
+   --rm \
+   --env PUBSUB_DEFAULT_PROJECT_ID=my-gcp-project \
    --publish 9090:80 \
    ghcr.io/drehelis/gcp-emulator-ui:main
 ```
@@ -156,6 +167,7 @@ docker run \
 | `VITE_DATASTORE_BASE_URL` | `/datastore` | Firestore datastore-mode emulator endpoint |
 | `VITE_STORAGE_BASE_URL` | `/storage` | Storage emulator endpoint |
 | `VITE_FILE_SERVER_BASE_URL` | `/fs` | File server endpoint for Datastore import/export operations |
+| `PUBSUB_DEFAULT_PROJECT_ID` | _(none)_ | GCP project ID selected by default on startup |
 
 ## Development
 

--- a/deployments/generate-runtime-config.sh
+++ b/deployments/generate-runtime-config.sh
@@ -29,5 +29,14 @@ else
     echo "No PUBSUB_PRE_CONFIGURED_MSG_ATTR environment variable found"
 fi
 
+if [ -n "$PUBSUB_DEFAULT_PROJECT_ID" ]; then
+    echo "Processing PUBSUB_DEFAULT_PROJECT_ID..."
+    CONFIG_JSON=$(echo "$CONFIG_JSON" | jq --arg id "$PUBSUB_DEFAULT_PROJECT_ID" \
+        '.pubsub.defaultProjectId = $id')
+    echo "  [✓] Default project ID set to: $PUBSUB_DEFAULT_PROJECT_ID"
+else
+    echo "No PUBSUB_DEFAULT_PROJECT_ID environment variable found"
+fi
+
 # Write the final configuration using jq for pretty formatting
 echo "$CONFIG_JSON" | jq '.' > "$CONFIG_FILE"

--- a/src/stores/__tests__/projects.test.ts
+++ b/src/stores/__tests__/projects.test.ts
@@ -333,7 +333,7 @@ describe('useProjectsStore', () => {
   })
 
   describe('initialize with config default', () => {
-    it('selects the default project from config on startup', () => {
+    it('selects the ENV-configured default project on initialization', () => {
       mockConfigStore.pubsubDefaultProjectId = 'config-default-project'
 
       const store = useProjectsStore()

--- a/src/stores/__tests__/projects.test.ts
+++ b/src/stores/__tests__/projects.test.ts
@@ -28,11 +28,20 @@ vi.mock('@/api/pubsub', () => ({
   },
 }))
 
+// Mock config store — default: no defaultProjectId set
+const mockConfigStore = {
+  pubsubDefaultProjectId: null as string | null,
+}
+vi.mock('../config', () => ({
+  useConfigStore: () => mockConfigStore,
+}))
+
 describe('useProjectsStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     localStorage.clear()
     vi.clearAllMocks()
+    mockConfigStore.pubsubDefaultProjectId = null
   })
 
   describe('initial state', () => {
@@ -319,6 +328,37 @@ describe('useProjectsStore', () => {
       const store = useProjectsStore()
       // Should not throw
       store.initialize()
+      expect(store.projectList).toEqual([])
+    })
+  })
+
+  describe('initialize with config default', () => {
+    it('selects the default project from config on startup', () => {
+      mockConfigStore.pubsubDefaultProjectId = 'config-default-project'
+
+      const store = useProjectsStore()
+      store.initialize()
+
+      expect(store.selectedProjectId).toBe('config-default-project')
+      expect(store.projectList).toContain('config-default-project')
+    })
+
+    it('persists config default to localStorage', () => {
+      mockConfigStore.pubsubDefaultProjectId = 'config-default-project'
+
+      const store = useProjectsStore()
+      store.initialize()
+
+      expect(localStorage.getItem('emulator-ui-selected-project-id')).toBe('config-default-project')
+    })
+
+    it('does nothing when config has no default project ID', () => {
+      mockConfigStore.pubsubDefaultProjectId = null
+
+      const store = useProjectsStore()
+      store.initialize()
+
+      expect(store.selectedProjectId).toBeNull()
       expect(store.projectList).toEqual([])
     })
   })

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -4,6 +4,7 @@ import { ref, computed, readonly } from 'vue'
 interface RuntimeConfig {
   pubsub?: {
     pubsubPreConfiguredMsgAttr?: Record<string, string>
+    defaultProjectId?: string
     // Add other pubsub configuration properties here
     [key: string]: any
   }
@@ -28,6 +29,10 @@ export const useConfigStore = defineStore('config', () => {
     }
 
     return {}
+  })
+
+  const pubsubDefaultProjectId = computed((): string | null => {
+    return runtimeConfig.value.pubsub?.defaultProjectId ?? null
   })
 
   // Actions
@@ -87,6 +92,7 @@ export const useConfigStore = defineStore('config', () => {
 
     // Getters
     pubsubPreConfiguredAttributes,
+    pubsubDefaultProjectId,
 
     // Actions
     loadRuntimeConfig,

--- a/src/stores/projects.ts
+++ b/src/stores/projects.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { pubsubApi } from '@/api/pubsub'
 import { useAppStore } from './app'
+import { useConfigStore } from './config'
 import type { GCPProject, SearchFilters, PaginationOptions, BaseStoreState } from '@/types'
 
 export const useProjectsStore = defineStore(
@@ -359,6 +360,17 @@ export const useProjectsStore = defineStore(
         }
       } catch {
         // Ignore
+      }
+
+      // Apply ENV-configured default project if set
+      try {
+        const configStore = useConfigStore()
+        const defaultId = configStore.pubsubDefaultProjectId
+        if (defaultId) {
+          selectProject(defaultId)
+        }
+      } catch {
+        // Ignore — config store unavailable
       }
     }
 


### PR DESCRIPTION
This pull request adds support for specifying a default GCP Pub/Sub project ID via an environment variable (`PUBSUB_DEFAULT_PROJECT_ID`). This enables the emulator UI to automatically select a default project on startup, improving user experience and configuration flexibility. The changes span environment configuration, documentation, runtime config processing, the config store, and the projects store, with accompanying tests to ensure correct behavior.

**Environment and Configuration Support:**
* Added `PUBSUB_DEFAULT_PROJECT_ID` to `.env.example` and updated the runtime config generator (`generate-runtime-config.sh`) to process this variable and inject it into the config JSON. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR5) [[2]](diffhunk://#diff-2b3bd4a8ea2f119fa70da2f12234a02991e1397253926b3b9014f57f2faa8f57R32-R40)

**Documentation Updates:**
* Updated `README.md` to document the new environment variable, its usage in Docker, and its effect on the UI. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R108) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R123-R132) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R170)

**Frontend Store Enhancements:**
* Extended the config store (`src/stores/config.ts`) to expose `pubsubDefaultProjectId`, reading it from runtime config. [[1]](diffhunk://#diff-3de048f03fcd6610cc2715285a4b2c11c7866866bfdb38d10b6b83b73bf9a9b9R7) [[2]](diffhunk://#diff-3de048f03fcd6610cc2715285a4b2c11c7866866bfdb38d10b6b83b73bf9a9b9R34-R37) [[3]](diffhunk://#diff-3de048f03fcd6610cc2715285a4b2c11c7866866bfdb38d10b6b83b73bf9a9b9R95)
* Updated the projects store (`src/stores/projects.ts`) so that, on initialization, it selects the configured default project if present. [[1]](diffhunk://#diff-93cfbb47e522740e586c4206ee67eb151ecd5d454f05826056358120db88b54fR5) [[2]](diffhunk://#diff-93cfbb47e522740e586c4206ee67eb151ecd5d454f05826056358120db88b54fR364-R374)

**Testing:**
* Added and updated tests to verify that the default project selection logic works as intended, including scenarios with and without a configured default. [[1]](diffhunk://#diff-3b41b82ab290325fd25d8f3b8b2b675083ce636e5a78b219c15caa51b80500b7R31-R44) [[2]](diffhunk://#diff-3b41b82ab290325fd25d8f3b8b2b675083ce636e5a78b219c15caa51b80500b7R335-R365)